### PR TITLE
Give ret a value to fix the build.

### DIFF
--- a/drivers/soc/qcom/ipc_router_hsic_xprt.c
+++ b/drivers/soc/qcom/ipc_router_hsic_xprt.c
@@ -668,7 +668,7 @@ error:
 static int msm_ipc_router_hsic_xprt_probe(
 				struct platform_device *pdev)
 {
-	int ret;
+	int ret = 0;
 	struct msm_ipc_router_hsic_xprt_config hsic_xprt_config;
 
 	if (pdev && pdev->dev.of_node) {


### PR DESCRIPTION
Without this change, the build fails, because `ret` might have never been assigned a value when it gets returned.